### PR TITLE
Vector union is not the same as vector append

### DIFF
--- a/Control.jl
+++ b/Control.jl
@@ -244,7 +244,7 @@ function av(E, C, V::Vector{Vector{Char}}, U::Vector{Vector{Char}}, k, ctype::Co
 
     for i=0:k
         for j in IterTools.subsets(eachindex(U), i)
-            winners = E(C, ∪(V, U[j]), w)
+            winners = E(C, append!(V, U[j]), w)
 
             if ctype == CC
                 for c in winners


### PR DESCRIPTION
I re-ran `CheckAll.jl` and nothing in the tables seems to be affected by this bug but I am also not sure if the tables in the repo are the ones used in the paper.